### PR TITLE
Ensure content exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "zola-build": "zola build",
     "vite-serve": "vite serve",
     "vite-build": "vite build",
-    "dev": "npm-run-all --parallel vite-serve zola-serve",
-    "build": "export BUILD_MODE=production && npm-run-all vite-build zola-build"
+    "dev": "mkdir -p content && npm-run-all --parallel vite-serve zola-serve",
+    "build": "export BUILD_MODE=production && mkdir -p content && npm-run-all vite-build zola-build"
   }
 }


### PR DESCRIPTION
If you follow the README instructions you will get this error because the content directory is missing:
```
Error: Failed to serve the site
Error: Can't watch `content` for changes in folder `.../zola-vite-demo`. Does it exist, and do you have correct permissions?
Error: Reason: No path was found.
ERROR: "zola-serve" exited with 1.
```
This change ensures an empty content directory is present.